### PR TITLE
🔧 add renovate default config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root=true
+
+[*]
+charset = utf-8
+
+end_of_line = lf
+max_line_length = 120
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 2
+
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/renovate.default.json
+++ b/renovate.default.json
@@ -124,6 +124,37 @@
       ],
       "stabilityDays": 7,
       "dependencyDashboardApproval": true
+    },
+    {
+      "prPriority": -1,
+      "groupName": "mongo-major",
+      "matchPackagePatterns": [
+        "mongo",
+        "mongoose"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "prPriority": -1,
+      "groupName": "fastify-major",
+      "matchPackagePatterns": [
+        "fastify"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    },
+    {
+      "prPriority": -1,
+      "groupName": "pino-major",
+      "matchPackagePatterns": [
+        "pino"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
     }
   ]
 }

--- a/renovate.default.json
+++ b/renovate.default.json
@@ -1,0 +1,129 @@
+{
+  "enabled": true,
+  "dependencyDashboard": true,
+  "timezone": "Europe/Paris",
+  "schedule": [],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 5,
+  "postUpdateOptions": [
+    "npmDedupe"
+  ],
+  "labels": [
+    "renovate",
+    "dependencies",
+    "self-hosted"
+  ],
+  "enabledManagers": [
+    "npm"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "node",
+        "npm"
+      ],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "@types/node"
+      ],
+      "allowedVersions": "<17"
+    },
+    {
+      "matchCurrentVersion": "<1.0.0",
+      "stabilityDays": 7,
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "stabilityDays": 7,
+      "dependencyDashboardApproval": true
+    },
+    {
+      "prPriority": 1,
+      "groupName": "test",
+      "matchPackagePatterns": [
+        "jest",
+        "nyc",
+        "sinon",
+        "chai",
+        "mocha",
+        "nock",
+        "supertest"
+      ],
+      "automerge": true
+    },
+    {
+      "prPriority": 1,
+      "groupName": "linter",
+      "matchPackagePatterns": [
+        "eslint",
+        "lint-staged",
+        "prettier"
+      ],
+      "automerge": true
+    },
+    {
+      "prPriority": 1,
+      "groupName": "types",
+      "matchPackagePatterns": [
+        "@types/*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": ">=1.0.0",
+      "automerge": true
+    },
+    {
+      "prPriority": 1,
+      "groupName": "typescript-non-major",
+      "matchPackageNames": [
+        "ts-node",
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "prPriority": 0,
+      "groupName": "all-non-major",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "excludePackageNames": [
+        "@types/node",
+        "ts-node",
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": ">=1.0.0"
+    },
+    {
+      "prPriority": -1,
+      "groupName": "typescript-major",
+      "matchPackageNames": [
+        "ts-node",
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "stabilityDays": 7,
+      "dependencyDashboardApproval": true
+    }
+  ]
+}


### PR DESCRIPTION
j'ai fait un merge des conf de nocturne, denis-cli et de georges
le preset ne contient que des règles concernant des packages "générique"
- c'est pour cela que l'on retrouve les règles de linter, test, typescript,...
- c'est pour cela que l'on ne retrouve pas les règles mongo, fastify,... qui sont spécifique à chaque repo

Nous aurons donc, par défault:
- merge auto des linter, type, test
- pr créer auto pour les minor et les patch
- major créer manuellement depuis l'interface

le reste (ex: groupement de packages pour les majeur), c'est dans chaque repo