### PR TITLE
feat: limit renovate to non-working hours

### DIFF
--- a/renovate.default.json
+++ b/renovate.default.json
@@ -2,7 +2,10 @@
   "enabled": true,
   "dependencyDashboard": true,
   "timezone": "Europe/Paris",
-  "schedule": [],
+  "schedule": [
+    "after 7pm and before 7am every weekday",
+    "every weekend"
+  ],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 5,
   "reviewersFromCodeOwners": true,

--- a/renovate.monorepo.json
+++ b/renovate.monorepo.json
@@ -2,7 +2,10 @@
   "enabled": true,
   "dependencyDashboard": true,
   "timezone": "Europe/Paris",
-  "schedule": [],
+  "schedule": [
+    "after 7pm and before 7am every weekday",
+    "every weekend"
+  ],
   "rangeStrategy": "bump",
   "prConcurrentLimit": 5,
   "reviewersFromCodeOwners": true,


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#schedule

Pas moyen "d'arreter" renovate
C'est un peu le but du bot de rester à jour
Par contre, on peut lui dire de se mettre à jours que la nuit et le week-end
